### PR TITLE
Use endroid/qr-code instead of endroid/qrcode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "typo3fluid/fluid": "*",
         "zendframework/zend-cache": "2.5.*",
         "zendframework/zend-serializer": "2.5.*",
-        "endroid/qrcode": "^1.5",
+        "endroid/qr-code": "^1.5",
         "gajus/dindent": "2.0.*"
     },
     "authors": [


### PR DESCRIPTION
Resolves warning "Package endroid/qrcode is abandoned, you should avoid using it. Use endroid/qr-code instead."